### PR TITLE
修复默认时区非UTC情况下日期错误导致签名失败。

### DIFF
--- a/src/Signer.php
+++ b/src/Signer.php
@@ -75,7 +75,7 @@ class Signer
             $signedHeaders . "\n" .
             $payloadHash;
 
-        $date = date("Y-m-d", $timestamp);
+        $date = gmdate("Y-m-d", $timestamp);
         $service = explode(".", $endpoint)[0];
 
         $algorithm = "TC3-HMAC-SHA256";


### PR DESCRIPTION
假如系统的时区为PRC，在凌晨跨日期的时候必现。

顺便说下：
[https://github.com/TencentCloudBase/tencentcloud-client-php/blob/402f0e2f7abb61642440ec987f33a65db9f19f78/src/Utils.php#L8](https://github.com/TencentCloudBase/tencentcloud-client-php/blob/402f0e2f7abb61642440ec987f33a65db9f19f78/src/Utils.php#L8)

这里的time()获取不受时区的影响。